### PR TITLE
Fix import issue

### DIFF
--- a/Template Aruba VC.xml
+++ b/Template Aruba VC.xml
@@ -846,7 +846,7 @@
                             <type>15</type>
                             <snmp_community/>
                             <snmp_oid/>
-                            <key>iAPUsedMemory</key>
+                            <key>iAPUsedMemory.[{#APNAME}]</key>
                             <delay>60s</delay>
                             <history>90d</history>
                             <trends>365d</trends>


### PR DESCRIPTION
If you try to import this template, zabbix refuses this because one item prototype is missing the LLD var {#APNAME}. 